### PR TITLE
Add actions read permission to open pr workflow

### DIFF
--- a/.github/workflows/open-pr-on-commit.yaml
+++ b/.github/workflows/open-pr-on-commit.yaml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      actions: read # required for gh pr view in private repos
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is needed for private repos, otherwise commits to the PR branch will fail the status check after the initial commit
> GraphQL: Resource not accessible by integration (repository.pullRequests.nodes.0.statusCheckRollup.nodes.0.commit.statusCheckRollup)